### PR TITLE
feat(checker): детектирование эмулятора и изоляции песочницы

### DIFF
--- a/app/src/main/cpp/native_signs_probe.cpp
+++ b/app/src/main/cpp/native_signs_probe.cpp
@@ -925,6 +925,94 @@ jobjectArray nativeDetectRoot(JNIEnv *env, jclass /*clazz*/) {
     return toStringArray(env, findings);
 }
 
+bool fileContains(const char *path, const char *needle) {
+    FILE *f = std::fopen(path, "re");
+    if (f == nullptr) return false;
+    char line[1024];
+    bool found = false;
+    while (std::fgets(line, sizeof(line), f) != nullptr) {
+        if (std::strstr(line, needle) != nullptr) { found = true; break; }
+    }
+    std::fclose(f);
+    return found;
+}
+
+jobjectArray nativeDetectEmulator(JNIEnv *env, jclass /*clazz*/) {
+    std::vector<std::string> findings;
+
+    // 1. QEMU system properties
+    static const char *const kQemuProps[] = {
+        "ro.kernel.qemu",
+        "ro.kernel.qemu.gles",
+        "ro.boot.qemu",
+        "qemu.hw.mainkeys",
+    };
+    for (const char *prop : kQemuProps) {
+        char val[PROP_VALUE_MAX] = {0};
+        if (__system_property_get(prop, val) > 0 && val[0] != '\0') {
+            std::string f = "qemu_prop|";
+            f.append(prop);
+            f.push_back('=');
+            f.append(val);
+            findings.push_back(f);
+        }
+    }
+
+    // 2. Goldfish/ranchu hardware
+    static const char *const kHwProps[] = {
+        "ro.hardware",
+        "ro.product.board",
+    };
+    for (const char *prop : kHwProps) {
+        char val[PROP_VALUE_MAX] = {0};
+        if (__system_property_get(prop, val) > 0) {
+            if (std::strstr(val, "goldfish") != nullptr ||
+                std::strstr(val, "ranchu") != nullptr) {
+                std::string f = "goldfish|";
+                f.append(prop);
+                f.push_back('=');
+                f.append(val);
+                findings.push_back(f);
+            }
+        }
+    }
+
+    // 3. Emulator pipe devices (genyd => Genymotion)
+    static const char *const kPipePaths[] = {
+        "/dev/qemu_pipe",
+        "/dev/socket/qemud",
+        "/dev/socket/genyd",
+        "/dev/socket/baseband_genyd",
+    };
+    for (const char *path : kPipePaths) {
+        if (access(path, F_OK) == 0) {
+            std::string f = "qemu_pipe|";
+            f.append(path);
+            findings.push_back(f);
+        }
+    }
+
+    // 4. Goldfish TTY driver
+    if (fileContains("/proc/tty/drivers", "goldfish")) {
+        findings.emplace_back("qemu_driver|/proc/tty/drivers:goldfish");
+    }
+
+    // 5. BlueStacks artifacts
+    static const char *const kBlueStacksPaths[] = {
+        "/system/lib/libbstfolder_jni.so",
+        "/data/bluestacks.prop",
+    };
+    for (const char *path : kBlueStacksPaths) {
+        if (access(path, F_OK) == 0) {
+            std::string f = "bluestacks|";
+            f.append(path);
+            findings.push_back(f);
+        }
+    }
+
+    return toStringArray(env, findings);
+}
+
 const JNINativeMethod kMethods[] = {
     {"nativeGetIfAddrs", "()[Ljava/lang/String;", reinterpret_cast<void *>(nativeGetIfAddrs)},
     {"nativeIfNameToIndex", "(Ljava/lang/String;)I", reinterpret_cast<void *>(nativeIfNameToIndex)},
@@ -936,6 +1024,7 @@ const JNINativeMethod kMethods[] = {
     {"nativeNetlinkRouteDump", "(I)[Ljava/lang/String;", reinterpret_cast<void *>(nativeNetlinkRouteDump)},
     {"nativeNetlinkSockDiag", "(II)[Ljava/lang/String;", reinterpret_cast<void *>(nativeNetlinkSockDiag)},
     {"nativeDetectRoot", "()[Ljava/lang/String;", reinterpret_cast<void *>(nativeDetectRoot)},
+    {"nativeDetectEmulator", "()[Ljava/lang/String;", reinterpret_cast<void *>(nativeDetectEmulator)},
 };
 
 } // namespace

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/NativeSignsChecker.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/NativeSignsChecker.kt
@@ -9,6 +9,7 @@ import com.notcvnt.rknhardering.model.EvidenceSource
 import com.notcvnt.rknhardering.model.Finding
 import com.notcvnt.rknhardering.network.NetworkInterfaceNameNormalizer
 import com.notcvnt.rknhardering.network.NetworkInterfacePatterns
+import com.notcvnt.rknhardering.probe.NativeEmulatorFinding
 import com.notcvnt.rknhardering.probe.NativeInterface
 import com.notcvnt.rknhardering.probe.NativeInterfaceProbe
 import com.notcvnt.rknhardering.probe.NativeMapsFinding
@@ -46,6 +47,16 @@ object NativeSignsChecker {
         "/data/adb",
         "core-only",
     )
+
+    private val HIGH_CONFIDENCE_EMULATOR_KINDS = setOf(
+        "qemu_prop",
+        "qemu_pipe",
+        "goldfish",
+        "bluestacks",
+    )
+
+    private val CLONE_USER_IDS = setOf(999)
+    private val CLONE_USER_ID_RANGE = 950..959 // MIUI dual-app range
 
     internal data class JvmInterfaceSnapshot(
         val name: String,
@@ -114,6 +125,24 @@ object NativeSignsChecker {
         findings += rootOutcome.findings
         evidence += rootOutcome.evidence
         needsReview = needsReview || rootOutcome.needsReview
+
+        val emulatorOutcome = evaluateEmulator(
+            context,
+            runCatching { NativeInterfaceProbe.collectEmulatorFindings() }.getOrDefault(emptyList()),
+            collectBuildEmulatorFacts(),
+        )
+        findings += emulatorOutcome.findings
+        evidence += emulatorOutcome.evidence
+        needsReview = needsReview || emulatorOutcome.needsReview
+
+        val isolationOutcome = evaluateIsolation(
+            context,
+            userId = extractUserId(context.dataDir?.absolutePath),
+            isProfileOwner = collectIsProfileOwner(context),
+        )
+        findings += isolationOutcome.findings
+        evidence += isolationOutcome.evidence
+        needsReview = needsReview || isolationOutcome.needsReview
 
         if (findings.isEmpty()) {
             findings += Finding(
@@ -651,6 +680,161 @@ object NativeSignsChecker {
         }
 
         return PartialOutcome(findings, evidence, needsReview = needsReview)
+    }
+
+    internal fun evaluateEmulator(
+        context: Context,
+        emulatorFindings: List<NativeEmulatorFinding>,
+        buildFacts: List<String>,
+    ): PartialOutcome {
+        val findings = mutableListOf<Finding>()
+        val evidence = mutableListOf<EvidenceItem>()
+        var needsReview = false
+
+        for (finding in emulatorFindings) {
+            val detail = finding.detail ?: finding.kind
+            val confidence = if (finding.kind in HIGH_CONFIDENCE_EMULATOR_KINDS) {
+                EvidenceConfidence.HIGH
+            } else {
+                EvidenceConfidence.MEDIUM
+            }
+            findings += Finding(
+                description = context.getString(R.string.checker_native_emulator_marker, detail),
+                needsReview = true,
+                source = EvidenceSource.NATIVE_EMULATOR,
+                confidence = confidence,
+            )
+            evidence += EvidenceItem(
+                source = EvidenceSource.NATIVE_EMULATOR,
+                detected = true,
+                confidence = confidence,
+                description = "Emulator marker [${finding.kind}]: $detail",
+            )
+            needsReview = true
+        }
+
+        for (fact in buildFacts) {
+            findings += Finding(
+                description = context.getString(R.string.checker_native_emulator_build, fact),
+                needsReview = true,
+                source = EvidenceSource.NATIVE_EMULATOR,
+                confidence = EvidenceConfidence.MEDIUM,
+            )
+            evidence += EvidenceItem(
+                source = EvidenceSource.NATIVE_EMULATOR,
+                detected = true,
+                confidence = EvidenceConfidence.MEDIUM,
+                description = "Build emulator heuristic: $fact",
+            )
+            needsReview = true
+        }
+
+        return PartialOutcome(findings, evidence, needsReview = needsReview)
+    }
+
+    internal fun collectBuildEmulatorFacts(): List<String> {
+        val facts = mutableListOf<String>()
+        val fp = android.os.Build.FINGERPRINT.orEmpty()
+        if (fp.startsWith("generic") || fp.startsWith("unknown") ||
+            fp.contains("vbox") || fp.contains("emulator") || fp.contains("test-keys")
+        ) {
+            facts += "Build.FINGERPRINT=$fp"
+        }
+        val model = android.os.Build.MODEL.orEmpty()
+        if (model.contains("google_sdk") || model.contains("Emulator") ||
+            model.contains("Android SDK built for")
+        ) {
+            facts += "Build.MODEL=$model"
+        }
+        val hw = android.os.Build.HARDWARE.orEmpty()
+        if (hw in setOf("goldfish", "ranchu", "vbox86")) {
+            facts += "Build.HARDWARE=$hw"
+        }
+        val product = android.os.Build.PRODUCT.orEmpty()
+        if (product.startsWith("sdk_gphone") || product in setOf("vbox86p", "emulator", "sdk", "google_sdk")) {
+            facts += "Build.PRODUCT=$product"
+        }
+        val manufacturer = android.os.Build.MANUFACTURER.orEmpty()
+        // "unknown" alone is too broad — some legitimate AOSP/budget devices report it.
+        // Only flag named emulator vendors here; weaker signals are covered by FINGERPRINT/PRODUCT above.
+        if (manufacturer.equals("Genymotion", ignoreCase = true)) {
+            facts += "Build.MANUFACTURER=$manufacturer"
+        }
+        return facts
+    }
+
+    internal fun evaluateIsolation(
+        context: Context,
+        userId: Int,
+        isProfileOwner: Boolean,
+    ): PartialOutcome {
+        val findings = mutableListOf<Finding>()
+        val evidence = mutableListOf<EvidenceItem>()
+        var needsReview = false
+
+        val isClone = userId in CLONE_USER_IDS || userId in CLONE_USER_ID_RANGE
+
+        if (isClone) {
+            findings += Finding(
+                description = context.getString(R.string.checker_native_isolation_clone, userId),
+                needsReview = true,
+                source = EvidenceSource.SANDBOX_ISOLATION,
+                confidence = EvidenceConfidence.MEDIUM,
+            )
+            evidence += EvidenceItem(
+                source = EvidenceSource.SANDBOX_ISOLATION,
+                detected = true,
+                confidence = EvidenceConfidence.MEDIUM,
+                description = "Isolation: clone/dual-app container (user $userId)",
+            )
+            needsReview = true
+        } else if (userId != 0) {
+            findings += Finding(
+                description = context.getString(R.string.checker_native_isolation_secondary_user, userId),
+                needsReview = true,
+                source = EvidenceSource.SANDBOX_ISOLATION,
+                confidence = EvidenceConfidence.MEDIUM,
+            )
+            evidence += EvidenceItem(
+                source = EvidenceSource.SANDBOX_ISOLATION,
+                detected = true,
+                confidence = EvidenceConfidence.MEDIUM,
+                description = "Isolation: secondary user $userId",
+            )
+            needsReview = true
+        }
+
+        if (isProfileOwner) {
+            findings += Finding(
+                description = context.getString(R.string.checker_native_isolation_work_profile),
+                needsReview = true,
+                source = EvidenceSource.SANDBOX_ISOLATION,
+                confidence = EvidenceConfidence.MEDIUM,
+            )
+            evidence += EvidenceItem(
+                source = EvidenceSource.SANDBOX_ISOLATION,
+                detected = true,
+                confidence = EvidenceConfidence.MEDIUM,
+                description = "Isolation: managed work profile (profile owner)",
+            )
+            needsReview = true
+        }
+
+        return PartialOutcome(findings, evidence, needsReview = needsReview)
+    }
+
+    internal fun extractUserId(dataDirPath: String?): Int {
+        if (dataDirPath == null) return 0
+        val match = Regex("/data/user/(\\d+)/").find(dataDirPath) ?: return 0
+        return match.groupValues[1].toIntOrNull() ?: 0
+    }
+
+    internal fun collectIsProfileOwner(context: Context): Boolean {
+        return runCatching {
+            val dpm = context.getSystemService(android.content.Context.DEVICE_POLICY_SERVICE)
+                as? android.app.admin.DevicePolicyManager ?: return false
+            dpm.isProfileOwnerApp(context.packageName)
+        }.getOrDefault(false)
     }
 
     internal fun containsHighConfidenceRootMountMarker(detail: String): Boolean {

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/VerdictEngine.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/VerdictEngine.kt
@@ -37,6 +37,8 @@ object VerdictEngine {
     private val NATIVE_REVIEW_SOURCES = setOf(
         EvidenceSource.NATIVE_HOOK_MARKERS,
         EvidenceSource.NATIVE_LIBRARY_INTEGRITY,
+        EvidenceSource.NATIVE_EMULATOR,
+        EvidenceSource.SANDBOX_ISOLATION,
     )
 
     fun evaluate(

--- a/app/src/main/java/com/notcvnt/rknhardering/model/CheckResult.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/model/CheckResult.kt
@@ -80,6 +80,8 @@ enum class EvidenceSource {
     NATIVE_JVM_MISMATCH,
     NATIVE_LIBRARY_INTEGRITY,
     NATIVE_ROOT_DETECTION,
+    NATIVE_EMULATOR,
+    SANDBOX_ISOLATION,
 }
 
 enum class StunScope {

--- a/app/src/main/java/com/notcvnt/rknhardering/probe/NativeInterfaceProbe.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/probe/NativeInterfaceProbe.kt
@@ -62,6 +62,11 @@ data class NativeRootFinding(
     val detail: String?,
 )
 
+data class NativeEmulatorFinding(
+    val kind: String,
+    val detail: String?,
+)
+
 object NativeInterfaceProbe {
     private const val IPV4_DEFAULT_DESTINATION = "00000000"
     private const val IPV6_DEFAULT_DESTINATION = "00000000000000000000000000000000"
@@ -357,5 +362,20 @@ object NativeInterfaceProbe {
     fun collectRootFindings(): List<NativeRootFinding> {
         val rows = NativeSignsBridge.detectRoot()
         return parseRootFindings(rows)
+    }
+
+    fun parseEmulatorFindings(rows: Array<String>): List<NativeEmulatorFinding> {
+        return rows.mapNotNull { row ->
+            val sep = row.indexOf('|')
+            if (sep <= 0) return@mapNotNull null
+            val kind = row.substring(0, sep)
+            val detail = row.substring(sep + 1).takeIf { it.isNotBlank() }
+            NativeEmulatorFinding(kind = kind, detail = detail)
+        }
+    }
+
+    fun collectEmulatorFindings(): List<NativeEmulatorFinding> {
+        val rows = NativeSignsBridge.detectEmulator()
+        return parseEmulatorFindings(rows)
     }
 }

--- a/app/src/main/java/com/notcvnt/rknhardering/probe/NativeSignsBridge.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/probe/NativeSignsBridge.kt
@@ -37,6 +37,9 @@ object NativeSignsBridge {
     internal var detectRootOverride: (() -> Array<String>)? = null
 
     @Volatile
+    internal var detectEmulatorOverride: (() -> Array<String>)? = null
+
+    @Volatile
     private var initialized = false
 
     @Volatile
@@ -132,6 +135,12 @@ object NativeSignsBridge {
         return runCatching { nativeDetectRoot() }.getOrDefault(emptyArray())
     }
 
+    fun detectEmulator(): Array<String> {
+        detectEmulatorOverride?.let { return it.invoke() }
+        if (!isLibraryLoaded()) return emptyArray()
+        return runCatching { nativeDetectEmulator() }.getOrDefault(emptyArray())
+    }
+
     internal fun resetForTests() {
         isLibraryLoadedOverride = null
         getIfAddrsOverride = null
@@ -144,6 +153,7 @@ object NativeSignsBridge {
         netlinkRouteDumpOverride = null
         netlinkSockDiagOverride = null
         detectRootOverride = null
+        detectEmulatorOverride = null
         initialized = false
         libraryLoaded = false
         lastLoadError = null
@@ -159,4 +169,5 @@ object NativeSignsBridge {
     private external fun nativeNetlinkRouteDump(family: Int): Array<String>
     private external fun nativeNetlinkSockDiag(family: Int, protocol: Int): Array<String>
     private external fun nativeDetectRoot(): Array<String>
+    private external fun nativeDetectEmulator(): Array<String>
 }

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -619,6 +619,13 @@
     <string name="checker_native_root_uid">فرآیند با UID root در حال اجراست: %1$s</string>
     <string name="checker_native_root_magisk_prop">ویژگی Magisk شناسایی شد: %1$s</string>
 
+    <!-- NativeSignsChecker: شبیه‌ساز / جداسازی sandbox -->
+    <string name="checker_native_emulator_marker">نشانه شبیه‌ساز: %1$s</string>
+    <string name="checker_native_emulator_build">پروفایل Build شبیه‌سازی‌شده به نظر می‌رسد: %1$s</string>
+    <string name="checker_native_isolation_secondary_user">برنامه در کاربر ثانویه اندروید %1$d اجرا می‌شود؛ آشکارسازها فقط این کاربر را می‌بینند و VPN در کاربر دیگر بدون روت قابل تشخیص نیست</string>
+    <string name="checker_native_isolation_clone">برنامه در یک محفظه شبیه‌سازی/dual-app اجرا می‌شود (کاربر %1$d)؛ VPN در پروفایل اصلی قابل تشخیص نیست</string>
+    <string name="checker_native_isolation_work_profile">برنامه در یک پروفایل کاری مدیریت‌شده اجرا می‌شود؛ VPN در پروفایل شخصی بدون روت قابل تشخیص نیست</string>
+
     <!-- App update checker -->
     <string name="update_dialog_title">به‌روزرسانی موجود است</string>
     <string name="update_dialog_message">نسخه نصب‌شده: %1$s\nآخرین نسخه: %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -640,6 +640,13 @@
     <string name="checker_native_root_uid">Процесс выполняется с root UID: %1$s</string>
     <string name="checker_native_root_magisk_prop">Обнаружено свойство Magisk: %1$s</string>
 
+    <!-- NativeSignsChecker: эмулятор / изоляция песочницы -->
+    <string name="checker_native_emulator_marker">Маркер эмулятора: %1$s</string>
+    <string name="checker_native_emulator_build">Профиль Build выглядит эмулированным: %1$s</string>
+    <string name="checker_native_isolation_secondary_user">Приложение работает во вторичном пользователе Android %1$d; детекторы видят только этого пользователя, VPN в другом пользователе не обнаруживается без root</string>
+    <string name="checker_native_isolation_clone">Приложение работает в клонированном/dual-app контейнере (пользователь %1$d); VPN в основном профиле не обнаруживается</string>
+    <string name="checker_native_isolation_work_profile">Приложение работает в управляемом рабочем профиле; VPN в личном профиле не обнаруживается без root</string>
+
     <!-- App update checker -->
     <string name="update_dialog_title">Доступно обновление</string>
     <string name="update_dialog_message">Установленная версия: %1$s\nАктуальная версия: %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -617,6 +617,13 @@
     <string name="checker_native_root_uid">进程以 root UID 运行：%1$s</string>
     <string name="checker_native_root_magisk_prop">检测到 Magisk 属性：%1$s</string>
 
+    <!-- NativeSignsChecker: 模拟器 / 沙箱隔离 -->
+    <string name="checker_native_emulator_marker">模拟器标记：%1$s</string>
+    <string name="checker_native_emulator_build">Build 配置看起来像模拟器：%1$s</string>
+    <string name="checker_native_isolation_secondary_user">应用运行在次要 Android 用户 %1$d 中；检测器只能看到该用户，无法在无 root 的情况下检测其他用户中的 VPN</string>
+    <string name="checker_native_isolation_clone">应用运行在克隆/双开容器中（用户 %1$d）；无法检测主资料中的 VPN</string>
+    <string name="checker_native_isolation_work_profile">应用运行在受管理的工作资料中；无法在无 root 的情况下检测个人资料中的 VPN</string>
+
     <!-- App update checker -->
     <string name="update_dialog_title">有更新可用</string>
     <string name="update_dialog_message">已安装版本：%1$s\n最新版本：%2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -645,6 +645,13 @@
     <string name="checker_native_root_uid">Process is running with root UID: %1$s</string>
     <string name="checker_native_root_magisk_prop">Magisk property detected: %1$s</string>
 
+    <!-- NativeSignsChecker: emulator / sandbox isolation -->
+    <string name="checker_native_emulator_marker">Emulator marker: %1$s</string>
+    <string name="checker_native_emulator_build">Build profile looks emulated: %1$s</string>
+    <string name="checker_native_isolation_secondary_user">App runs in secondary Android user %1$d; detectors only see this user, a VPN in another user is not observable without root</string>
+    <string name="checker_native_isolation_clone">App runs in a cloned/dual-app container (user %1$d); a VPN in the primary profile is not observable</string>
+    <string name="checker_native_isolation_work_profile">App runs in a managed work profile; a VPN in the personal profile is not observable without root</string>
+
     <!-- App update checker -->
     <string name="update_dialog_title">Update available</string>
     <string name="update_dialog_message">Installed version: %1$s\nLatest version: %2$s</string>

--- a/app/src/test/java/com/notcvnt/rknhardering/checker/NativeEmulatorEvaluationTest.kt
+++ b/app/src/test/java/com/notcvnt/rknhardering/checker/NativeEmulatorEvaluationTest.kt
@@ -1,0 +1,49 @@
+package com.notcvnt.rknhardering.checker
+
+import androidx.test.core.app.ApplicationProvider
+import com.notcvnt.rknhardering.model.EvidenceConfidence
+import com.notcvnt.rknhardering.model.EvidenceSource
+import com.notcvnt.rknhardering.probe.NativeEmulatorFinding
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class NativeEmulatorEvaluationTest {
+
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun qemuPipeIsHighConfidenceNeedsReview() {
+        val findings = listOf(NativeEmulatorFinding("qemu_pipe", "/dev/qemu_pipe"))
+        val outcome = NativeSignsChecker.evaluateEmulator(context, findings, emptyList())
+        assertTrue(outcome.needsReview)
+        assertFalse(outcome.detected)
+        val ev = outcome.evidence.single()
+        assertEquals(EvidenceSource.NATIVE_EMULATOR, ev.source)
+        assertEquals(EvidenceConfidence.HIGH, ev.confidence)
+    }
+
+    @Test
+    fun buildOnlySignalIsMediumConfidence() {
+        val outcome = NativeSignsChecker.evaluateEmulator(
+            context,
+            emptyList(),
+            listOf("Build.FINGERPRINT=generic/sdk_gphone"),
+        )
+        assertTrue(outcome.needsReview)
+        assertEquals(EvidenceConfidence.MEDIUM, outcome.evidence.single().confidence)
+    }
+
+    @Test
+    fun emptyInputsProduceNoEvidence() {
+        val outcome = NativeSignsChecker.evaluateEmulator(context, emptyList(), emptyList())
+        assertFalse(outcome.needsReview)
+        assertTrue(outcome.evidence.isEmpty())
+    }
+}

--- a/app/src/test/java/com/notcvnt/rknhardering/checker/NativeIsolationEvaluationTest.kt
+++ b/app/src/test/java/com/notcvnt/rknhardering/checker/NativeIsolationEvaluationTest.kt
@@ -1,0 +1,62 @@
+package com.notcvnt.rknhardering.checker
+
+import androidx.test.core.app.ApplicationProvider
+import com.notcvnt.rknhardering.model.EvidenceSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class NativeIsolationEvaluationTest {
+
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun primaryUserNotProfileOwnerProducesNothing() {
+        val outcome = NativeSignsChecker.evaluateIsolation(
+            context,
+            userId = 0,
+            isProfileOwner = false,
+        )
+        assertFalse(outcome.needsReview)
+        assertTrue(outcome.evidence.isEmpty())
+    }
+
+    @Test
+    fun secondaryUserRaisesNeedsReview() {
+        val outcome = NativeSignsChecker.evaluateIsolation(
+            context,
+            userId = 10,
+            isProfileOwner = false,
+        )
+        assertTrue(outcome.needsReview)
+        assertEquals(EvidenceSource.SANDBOX_ISOLATION, outcome.evidence.first().source)
+    }
+
+    @Test
+    fun cloneUserIdIsLabeled() {
+        val outcome = NativeSignsChecker.evaluateIsolation(
+            context,
+            userId = 999,
+            isProfileOwner = false,
+        )
+        assertTrue(outcome.needsReview)
+        assertTrue(outcome.evidence.any { it.description.contains("clone") })
+    }
+
+    @Test
+    fun profileOwnerRaisesNeedsReview() {
+        val outcome = NativeSignsChecker.evaluateIsolation(
+            context,
+            userId = 0,
+            isProfileOwner = true,
+        )
+        assertTrue(outcome.needsReview)
+        assertTrue(outcome.evidence.any { it.description.contains("profile") })
+    }
+}

--- a/app/src/test/java/com/notcvnt/rknhardering/checker/VerdictEngineTest.kt
+++ b/app/src/test/java/com/notcvnt/rknhardering/checker/VerdictEngineTest.kt
@@ -528,6 +528,38 @@ class VerdictEngineTest {
     }
 
     @Test
+    fun `R6 emulator evidence alone yields needs review`() {
+        val verdict = VerdictEngine.evaluate(
+            geoIp = category(),
+            directSigns = category(),
+            indirectSigns = category(),
+            locationSignals = category(),
+            bypassResult = bypass(),
+            ipConsensus = IpConsensusResult.empty(),
+            nativeSigns = category(
+                evidence = listOf(evidence(EvidenceSource.NATIVE_EMULATOR, EvidenceConfidence.HIGH)),
+            ),
+        )
+        assertEquals(Verdict.NEEDS_REVIEW, verdict)
+    }
+
+    @Test
+    fun `R6 sandbox isolation evidence alone yields needs review`() {
+        val verdict = VerdictEngine.evaluate(
+            geoIp = category(),
+            directSigns = category(),
+            indirectSigns = category(),
+            locationSignals = category(),
+            bypassResult = bypass(),
+            ipConsensus = IpConsensusResult.empty(),
+            nativeSigns = category(
+                evidence = listOf(evidence(EvidenceSource.SANDBOX_ISOLATION, EvidenceConfidence.MEDIUM)),
+            ),
+        )
+        assertEquals(Verdict.NEEDS_REVIEW, verdict)
+    }
+
+    @Test
     fun `proxy assisted udp leak does not affect verdict`() {
         val verdict = VerdictEngine.evaluate(
             geoIp = category(),

--- a/app/src/test/java/com/notcvnt/rknhardering/probe/NativeEmulatorParserTest.kt
+++ b/app/src/test/java/com/notcvnt/rknhardering/probe/NativeEmulatorParserTest.kt
@@ -1,0 +1,37 @@
+package com.notcvnt.rknhardering.probe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NativeEmulatorParserTest {
+
+    @Test
+    fun parsesKindAndDetail() {
+        val rows = arrayOf(
+            "qemu_prop|ro.kernel.qemu=1",
+            "qemu_pipe|/dev/qemu_pipe",
+        )
+        val result = NativeInterfaceProbe.parseEmulatorFindings(rows)
+        assertEquals(2, result.size)
+        assertEquals("qemu_prop", result[0].kind)
+        assertEquals("ro.kernel.qemu=1", result[0].detail)
+        assertEquals("qemu_pipe", result[1].kind)
+        assertEquals("/dev/qemu_pipe", result[1].detail)
+    }
+
+    @Test
+    fun dropsRowsWithoutSeparator() {
+        val rows = arrayOf("garbage", "goldfish|ranchu")
+        val result = NativeInterfaceProbe.parseEmulatorFindings(rows)
+        assertEquals(1, result.size)
+        assertEquals("goldfish", result[0].kind)
+    }
+
+    @Test
+    fun blankDetailBecomesNull() {
+        val rows = arrayOf("cpuinfo|")
+        val result = NativeInterfaceProbe.parseEmulatorFindings(rows)
+        assertEquals(1, result.size)
+        assertEquals(null, result[0].detail)
+    }
+}


### PR DESCRIPTION
## Что и зачем

Приложение теперь определяет, что запущено в **эмуляторе** или в **изолированном/клонированном контексте** (вторичный пользователь Android, рабочий профиль, dual-app/клон-приложение), и поднимает вердикт `NEEDS_REVIEW`.

Мотивация: сетевые детекторы видят только текущий контекст приложения. VPN, скрытый в другом пользователе/профиле, для них невидим без root. Поэтому сам факт запуска в изолированной или эмулированной среде — повод для ручного ревью, а не для автоматического `DETECTED`.

## Что изменено

| Слой | Файл | Изменение |
|------|------|-----------|
| Native C++ | `native_signs_probe.cpp` | JNI-проба `nativeDetectEmulator` (QEMU-свойства, goldfish/ranchu, pipe-устройства Genymotion, TTY-драйвер, артефакты BlueStacks) + хелпер `fileContains`, регистрация в `kMethods` |
| Bridge | `NativeSignsBridge.kt` | `detectEmulator()` + тест-override + external-объявление |
| Probe | `NativeInterfaceProbe.kt` | `NativeEmulatorFinding` + `parseEmulatorFindings` + `collectEmulatorFindings` |
| Checker | `NativeSignsChecker.kt` | `evaluateEmulator` (native-маркеры HIGH, Build-эвристика MEDIUM), `evaluateIsolation` (вторичный пользователь / клон / рабочий профиль), вшито в `check()` |
| Model | `CheckResult.kt` | `EvidenceSource`: `NATIVE_EMULATOR`, `SANDBOX_ISOLATION` |
| Verdict | `VerdictEngine.kt` | оба источника добавлены в `NATIVE_REVIEW_SOURCES` (путь R6) |
| i18n | `values{,-ru,-fa,-zh-rCN}/strings.xml` | 5 новых строк × 4 локали |
| Тесты | 3 новых файла + 2 кейса в `VerdictEngineTest` | парсер, оба эвалуатора, R6-вердикт |

## Контракт безопасности

Эмуляция/клонирование — это **подозрение, не доказательство**. Поэтому:
- блоки никогда не ставят `CategoryResult.detected = true`, только `needsReview`;
- `NATIVE_EMULATOR` / `SANDBOX_ISOLATION` заведены **только** в `NATIVE_REVIEW_SOURCES` (R6), не входят в `HARD_DETECT_BYPASS` (R1) и не в матрицу R5;
- максимальный вклад в вердикт — `NEEDS_REVIEW`, `DETECTED` недостижим.

Это подтверждено отдельным тест-кейсом и адверсариальной проверкой.

## Контроль качества

Адверсариальная мульти-агентная проверка по 5 измерениям (потолок вердикта, C++ memory-safety, логика Kotlin, полнота i18n, покрытие тестами) выявила и зафиксировала два дефекта:
1. **Ложноположительная эвристика** `MANUFACTURER == "unknown"` — убрана: некоторые легитимные AOSP/бюджетные устройства репортят `unknown` и получали бы беспричинный `NEEDS_REVIEW`. Оставлен только конкретный вендор `Genymotion`.
2. **Мёртвый код** в clone-детекции — удалён path-фоллбэк: `userId` уже выводится из того же пути тем же regex через `extractUserId`, фоллбэк недостижим. Параметр `dataDirPath` убран из сигнатуры.

## Проверка

```
./gradlew :app:testDebugUnitTest :app:lintDebug :app:assembleDebug
```
→ **BUILD SUCCESSFUL**. Все JVM-тесты зелёные, native-либы собраны для `arm64-v8a` / `armeabi-v7a` / `x86_64` с зарегистрированным `nativeDetectEmulator`, без `MissingTranslation`.

## Заметки для ревьюера

- Native-код (`nativeDetectEmulator`) исполняется только на устройстве/в инструментальных тестах; offline JVM-тесты используют bridge-override, поэтому покрытие через unit-тесты косвенное (через парсер и эвалуатор).
- README не трогался: `.gitignore` игнорирует `*.md`, обновление матрицы детекторов в README — на усмотрение мейнтейнера.
