### PR TITLE
Обновили методичку

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ release.jks
 *.sh
 *.ps1
 !CONTRIBUTING.md
+!AGENTS.md
 !app/src/test/resources/export/golden/*.md
 /.codex
 .marketplace-keys/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+## Build & Test Commands
+
+```bash
+./gradlew assembleDebug          # build debug APK
+./gradlew lintDebug              # lint (CI runs this first)
+./gradlew testDebugUnitTest      # unit tests (Robolectric)
+```
+
+CI order: lint → build → test. Follow this locally if unsure.
+
+Single test class:
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.notcvnt.rknhardering.checker.VerdictEngineTest"
+```
+
+Marketplace hash regeneration (after editing any `.rkncheck` profile):
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.notcvnt.rknhardering.customcheck.MarketplaceHashGeneratorTest" -i
+```
+Paste output into `expected_hash` in `marketplace/catalog.json` for the matching profile.
+
+## SDK & Toolchain Requirements
+
+- JDK 17+ (CI uses JDK 21)
+- Android SDK: `platforms;android-36`, `build-tools;35.0.0`
+- NDK `28.2.13676358`, CMake `3.22.1`
+- Kotlin 1.9.25, AGP 8.9.2
+- ABI filters: `arm64-v8a`, `armeabi-v7a`, `x86_64` (no x86)
+
+## Project Structure
+
+Two Gradle modules:
+- **`:app`** — main Android application (Kotlin + JNI/C++)
+- **`:xray-protos`** — protobuf/gRPC stubs for Xray API (java-library, no Android)
+
+Entry point: `app/src/main/java/com/notcvnt/rknhardering/`
+
+Native code (`app/src/main/cpp/`): two shared libraries built via CMake:
+- `native_curl_probe` — HTTP probes using vendored curl + mbedTLS
+- `native_signs_probe` — JNI checks (interfaces, routes, /proc, emulator detection)
+
+Third-party native sources are vendored zips in `app/src/main/cpp/third_party/`.
+
+## Robolectric Tests
+
+Tests use Robolectric with offline mode. The build configures:
+- `robolectric.offline=true`
+- SDK 33 and 35 runtime jars copied to `build/robolectric-runtime-deps`
+- Isolated `user.home` and `java.io.tmpdir` under `build/`
+
+Do not override these system properties manually. Golden fixtures live in `app/src/test/resources/export/golden/`.
+
+## Version Management
+
+- Default version in `gradle.properties`: `appVersionName=2.6.8`
+- Release builds: version derived from git tag (`v1.2.3` → `versionName=1.2.3`, `versionCode=major*10000+minor*100+patch`)
+- Release CI validates that `versionName`/`versionCode` in `app/build.gradle.kts` match the tag
+- Reproducible builds via `SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)`
+
+## Marketplace Profiles
+
+Profiles are `.rkncheck` JSON files in `marketplace/checks/`. Catalog at `marketplace/catalog.json` is signed (`catalog.sig`). See `marketplace/CONTRIBUTING.md` for full schema and submission process.
+
+After editing any profile body, regenerate the hash (command above) and update the catalog in the same PR.
+
+## Key Architecture
+
+Checkers run in parallel via `VpnCheckRunner`. `VerdictEngine` computes the final verdict from evidence. `IpConsensusBuilder` cross-references GeoIP, IP comparison, CDN, and probe signals.
+
+`IpComparisonChecker` is diagnostic only (shown in UI) — it feeds `IpConsensusBuilder` but does not directly enter `VerdictEngine`.
+
+## .gitignore Note
+
+`*.md` is gitignored at root. `AGENTS.md` and `CONTRIBUTING.md` have explicit exceptions. If you add new root-level `.md` files, add a `!filename` exception to `.gitignore`.

--- a/app/src/main/java/com/notcvnt/rknhardering/MainActivity.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/MainActivity.kt
@@ -1134,7 +1134,9 @@ class MainActivity : AppCompatActivity() {
             -> R.string.simple_verdict_address_conflict
             VerdictRuleCode.R4_LOCATION_GEO_CONFLICT -> R.string.simple_verdict_location_conflict
             VerdictRuleCode.R4_HOSTING_REVIEW -> R.string.simple_verdict_hosting_review
-            VerdictRuleCode.R5_MATRIX -> R.string.simple_verdict_combined_signals
+            VerdictRuleCode.R5_MATRIX,
+            VerdictRuleCode.R5_MATRIX_DEFAULT,
+            -> R.string.simple_verdict_combined_signals
             VerdictRuleCode.R6_FALLBACK -> R.string.simple_verdict_review_signals
             VerdictRuleCode.UNSPECIFIED -> R.string.simple_verdict_general
         },

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/CdnPullingChecker.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/CdnPullingChecker.kt
@@ -10,6 +10,7 @@ import com.notcvnt.rknhardering.customcheck.mapper.MappingField
 import com.notcvnt.rknhardering.model.CdnPullingResponse
 import com.notcvnt.rknhardering.model.CdnPullingResult
 import com.notcvnt.rknhardering.model.EvidenceConfidence
+import com.notcvnt.rknhardering.model.EvidenceSource
 import com.notcvnt.rknhardering.model.Finding
 import com.notcvnt.rknhardering.network.DnsResolverConfig
 import com.notcvnt.rknhardering.probe.CdnPullingClient
@@ -343,7 +344,11 @@ object CdnPullingChecker {
 
         val allSuccessfulResponsesExposeIp = successfulResponses.isNotEmpty() && successfulResponses.all { it.ip != null }
         val hasError = successfulCount == 0
-        val detected = actionableCount > 0
+        val proxyHeaderDetected = successfulResponses.any { response ->
+            detectProxyHeadersFromFields(response.importantFields).isNotEmpty() ||
+                detectProxyHeadersFromBody(response.rawBody).isNotEmpty()
+        }
+        val detected = actionableCount > 0 || proxyHeaderDetected
 
         val ipv4Conflict = actionableIpv4s.size > 1
         val ipv6Conflict = actionableIpv6s.size > 1
@@ -412,6 +417,49 @@ object CdnPullingChecker {
         )
     }
 
+    internal fun detectProxyHeadersFromFields(
+        fieldMap: Map<String, String>,
+    ): List<Finding> {
+        val findings = mutableListOf<Finding>()
+        // Cloudflare returns lowercase "warp" in /cdn-cgi/trace
+        val warpValue = fieldMap["warp"]?.lowercase()
+            ?: fieldMap["WARP"]?.lowercase()
+        if (warpValue == "on" || warpValue == "plus") {
+            findings += Finding(
+                description = "Cloudflare WARP detected in CDN response: ${fieldMap["warp"] ?: fieldMap["WARP"]}",
+                detected = true,
+                source = EvidenceSource.HTTP_PROXY_HEADER,
+                confidence = EvidenceConfidence.MEDIUM,
+            )
+        }
+        return findings
+    }
+
+    internal fun detectProxyHeadersFromBody(rawBody: String?): List<Finding> {
+        if (rawBody == null) return emptyList()
+        val findings = mutableListOf<Finding>()
+        val lower = rawBody.lowercase()
+        if (lower.contains("x-forwarded-for") || lower.contains("x-forwarded-proto") ||
+            lower.contains("x-forwarded-host")
+        ) {
+            findings += Finding(
+                description = "Response body contains X-Forwarded-* proxy headers (possible proxy traversal)",
+                detected = true,
+                source = EvidenceSource.HTTP_PROXY_HEADER,
+                confidence = EvidenceConfidence.LOW,
+            )
+        }
+        if (lower.contains("forwarded:") || lower.contains("via:")) {
+            findings += Finding(
+                description = "Response body contains Forwarded/Via proxy headers",
+                detected = true,
+                source = EvidenceSource.HTTP_PROXY_HEADER,
+                confidence = EvidenceConfidence.LOW,
+            )
+        }
+        return findings
+    }
+
     private fun buildFindings(
         successfulResponses: List<CdnPullingResponse>,
         allResponses: List<CdnPullingResponse>,
@@ -432,6 +480,9 @@ object CdnPullingChecker {
                 isInformational = true,
                 confidence = EvidenceConfidence.MEDIUM,
             )
+
+            findings += detectProxyHeadersFromFields(response.importantFields)
+            findings += detectProxyHeadersFromBody(response.rawBody)
         }
         allResponses.filter { it.error != null }.forEach { response ->
             findings += Finding(

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/CorporateVpnWhitelist.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/CorporateVpnWhitelist.kt
@@ -1,0 +1,138 @@
+package com.notcvnt.rknhardering.checker
+
+import com.notcvnt.rknhardering.model.GeoIpFacts
+
+data class CorporateVpnEntry(
+    val name: String,
+    val asns: Set<String> = emptySet(),
+    val orgPatterns: Set<String> = emptySet(),
+    val ispPatterns: Set<String> = emptySet(),
+    val ipRanges: Set<String> = emptySet(),
+) {
+    fun matches(facts: GeoIpFacts): Boolean {
+        if (facts.asnCode in asns) return true
+        if (facts.org?.let { org -> orgPatterns.any { pattern -> org.contains(pattern, ignoreCase = true) } } == true) return true
+        if (facts.isp?.let { isp -> ispPatterns.any { pattern -> isp.contains(pattern, ignoreCase = true) } } == true) return true
+        return false
+    }
+}
+
+object CorporateVpnWhitelist {
+
+    private val entries: List<CorporateVpnEntry> = listOf(
+        CorporateVpnEntry(
+            name = "Sberbank Corporate VPN",
+            asns = setOf("35237", "33844", "47457", "206673"),
+            orgPatterns = setOf("Sberbank", "Sberbank of Russia", "Sber"),
+            ispPatterns = setOf("Sberbank"),
+        ),
+        CorporateVpnEntry(
+            name = "VTB Bank Corporate VPN",
+            asns = setOf("41551", "24823", "41430"),
+            orgPatterns = setOf("VTB Bank", "VTB-AS"),
+            ispPatterns = setOf("VTB"),
+        ),
+        CorporateVpnEntry(
+            name = "Gazprombank Corporate VPN",
+            asns = setOf("35022"),
+            orgPatterns = setOf("Gazprombank", "GPB"),
+        ),
+        CorporateVpnEntry(
+            name = "Alfa-Bank Corporate VPN",
+            asns = setOf("15632", "208811"),
+            orgPatterns = setOf("Alfa-Bank", "AlfaBank", "ALFA-BANK"),
+        ),
+        CorporateVpnEntry(
+            name = "Rosselkhozbank Corporate VPN",
+            asns = setOf("41615"),
+            orgPatterns = setOf("Rosselkhozbank", "Russian Agricultural Bank", "RSHB"),
+        ),
+        CorporateVpnEntry(
+            name = "Central Bank of Russia (CBR)",
+            asns = setOf("4783"),
+            orgPatterns = setOf("Central Bank of the Russian Federation", "Bank of Russia", "CBR"),
+        ),
+        CorporateVpnEntry(
+            name = "Gazprom Corporate VPN",
+            asns = setOf("20576", "39045", "25032", "15757"),
+            orgPatterns = setOf("Gazprom", "Gazprom telecom", "Gazsvyaz", "Gaztelecom"),
+        ),
+        CorporateVpnEntry(
+            name = "Rosneft Corporate VPN",
+            asns = setOf("48079"),
+            orgPatterns = setOf("Rosneft", "NK Rosneft"),
+        ),
+        CorporateVpnEntry(
+            name = "Russian Railways (RZD) Corporate VPN",
+            asns = setOf("60569"),
+            orgPatterns = setOf("Russian Railways", "RZD", "Rossiyskie Zheleznye Dorogi"),
+        ),
+        CorporateVpnEntry(
+            name = "Aeroflot Corporate VPN",
+            asns = setOf("48065"),
+            orgPatterns = setOf("Aeroflot"),
+        ),
+        CorporateVpnEntry(
+            name = "Rostelecom Corporate VPN",
+            asns = setOf("12389", "8342"),
+            orgPatterns = setOf("Rostelecom", "RTComm"),
+            ispPatterns = setOf("Rostelecom"),
+        ),
+        CorporateVpnEntry(
+            name = "MTS Corporate VPN",
+            asns = setOf("8359", "16256"),
+            orgPatterns = setOf("MTS", "Mobile TeleSystems", "MTS PJSC"),
+        ),
+        CorporateVpnEntry(
+            name = "Beeline/VimpelCom Corporate VPN",
+            asns = setOf("8402", "3216"),
+            orgPatterns = setOf("VimpelCom", "Vimpelcom", "Beeline", "VEON"),
+        ),
+        CorporateVpnEntry(
+            name = "MegaFon Corporate VPN",
+            asns = setOf("31133", "6850", "25159"),
+            orgPatterns = setOf("MegaFon", "Megafon", "MF-MGSM"),
+        ),
+        CorporateVpnEntry(
+            name = "TransTeleCom Corporate VPN",
+            asns = setOf("20485"),
+            orgPatterns = setOf("TransTeleCom", "TTK"),
+        ),
+        CorporateVpnEntry(
+            name = "ER-Telecom (Dom.ru) Corporate VPN",
+            asns = setOf("9049", "12768", "31363"),
+            orgPatterns = setOf("ER-Telecom", "Dom.ru", "JSC ER-Telecom Holding"),
+        ),
+        CorporateVpnEntry(
+            name = "Yandex Cloud Corporate VPN",
+            asns = setOf("13238", "44534", "200350", "208682"),
+            orgPatterns = setOf("Yandex", "Yandex Cloud", "Yandex.Cloud"),
+            ispPatterns = setOf("Yandex"),
+        ),
+        CorporateVpnEntry(
+            name = "VK Corporate VPN",
+            asns = setOf("47764", "47541", "28709", "49797"),
+            orgPatterns = setOf("VK", "VKontakte", "Mail.Ru", "LLC VK"),
+            ispPatterns = setOf("VK", "Mail.Ru"),
+        ),
+        CorporateVpnEntry(
+            name = "Ministry of Digital Development",
+            asns = setOf("49604"),
+            orgPatterns = setOf("Ministry of Digital Development", "Minkomsvyaz"),
+        ),
+    )
+
+    @Volatile
+    internal var overrides: List<CorporateVpnEntry>? = null
+
+    private val activeEntries: List<CorporateVpnEntry>
+        get() = overrides ?: entries
+
+    fun match(facts: GeoIpFacts): CorporateVpnEntry? {
+        return activeEntries.firstOrNull { it.matches(facts) }
+    }
+
+    fun isWhitelisted(facts: GeoIpFacts): Boolean {
+        return match(facts) != null
+    }
+}

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/IndirectSignsChecker.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/IndirectSignsChecker.kt
@@ -24,6 +24,7 @@ import com.notcvnt.rknhardering.vpn.VpnAppCatalog
 import com.notcvnt.rknhardering.vpn.VpnAppMetadataScanner
 import com.notcvnt.rknhardering.vpn.VpnClientSignal
 import com.notcvnt.rknhardering.vpn.VpnDumpsysParser
+import android.util.Log
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -225,7 +226,13 @@ object IndirectSignsChecker {
 
         if (config.checkProxyTools) {
             val proxyTechnicalOutcome = IndirectCheckPerformanceSupport.measureStep("checkProxyTechnicalSignals", stepTimings) {
-                checkProxyTechnicalSignals(context, config.checkLocalListeners, config.listenerPortThreshold)
+                checkProxyTechnicalSignals(
+                    context = context,
+                    checkLocalListeners = config.checkLocalListeners,
+                    listenerPortThreshold = config.listenerPortThreshold,
+                    checkIptables = config.checkIptables,
+                    checkUserCerts = config.checkUserCerts,
+                )
             }
             findings += proxyTechnicalOutcome.findings
             evidence += proxyTechnicalOutcome.evidence
@@ -796,6 +803,8 @@ object IndirectSignsChecker {
         context: Context,
         checkLocalListeners: Boolean = true,
         listenerPortThreshold: Int = 5,
+        checkIptables: Boolean = true,
+        checkUserCerts: Boolean = true,
     ): ProxyTechnicalEvaluation {
         val installedProxyTools = detectInstalledProxyTools(context)
         val listeners = if (checkLocalListeners) collectLocalListeners(context) else emptyList()
@@ -898,7 +907,24 @@ object IndirectSignsChecker {
             }
         }
 
-        if (installedProxyTools.isEmpty() && listeners.isEmpty()) {
+        val iptablesOutcome = if (checkIptables) {
+            checkIptablesRules()
+        } else IptablesCheckOutcome(emptyList(), emptyList(), detected = false, needsReview = false)
+        findings += iptablesOutcome.findings
+        evidence += iptablesOutcome.evidence
+        detected = detected || iptablesOutcome.detected
+        needsReview = needsReview || iptablesOutcome.needsReview
+
+        val certOutcome = if (checkUserCerts) {
+            checkUserInstalledCertificates()
+        } else CertCheckOutcome(emptyList(), emptyList(), needsReview = false)
+        findings += certOutcome.findings
+        evidence += certOutcome.evidence
+        needsReview = needsReview || certOutcome.needsReview
+
+        if (installedProxyTools.isEmpty() && listeners.isEmpty() &&
+            iptablesOutcome.findings.isEmpty() && certOutcome.findings.isEmpty()
+        ) {
             findings.add(Finding(context.getString(R.string.checker_indirect_no_proxy_technical)))
         }
 
@@ -914,6 +940,176 @@ object IndirectSignsChecker {
             detected = detected,
             needsReview = needsReview,
         )
+    }
+
+    internal data class IptablesCheckOutcome(
+        val findings: List<Finding>,
+        val evidence: List<EvidenceItem>,
+        val detected: Boolean,
+        val needsReview: Boolean,
+    )
+
+    internal data class CertCheckOutcome(
+        val findings: List<Finding>,
+        val evidence: List<EvidenceItem>,
+        val needsReview: Boolean,
+    )
+
+    internal fun checkIptablesRules(): IptablesCheckOutcome {
+        val findings = mutableListOf<Finding>()
+        val evidence = mutableListOf<EvidenceItem>()
+        var detected = false
+        var needsReview = false
+        val hasAccess = runCatching {
+            File("/proc/net/ip_tables_names").takeIf { it.exists() }
+                ?.readText()?.isNotBlank() == true
+        }.getOrDefault(false)
+
+        if (!hasAccess) {
+            return IptablesCheckOutcome(findings, evidence, detected = false, needsReview = false)
+        }
+
+        val iptablesOutput: String? = runCatching {
+            val process = Runtime.getRuntime().exec(arrayOf("iptables", "-L", "-n", "-t", "nat"))
+            process.inputStream.bufferedReader().readText().takeIf { it.isNotBlank() }
+                .also { process.waitFor() }
+        }.getOrNull()
+
+        if (iptablesOutput != null && (iptablesOutput.contains("REDIRECT") ||
+                iptablesOutput.contains("DNAT") ||
+                iptablesOutput.lowercase().contains("tproxy"))
+        ) {
+            findings.add(
+                Finding(
+                    description = "iptables NAT rules show REDIRECT/DNAT/TPROXY (possible local proxy)",
+                    detected = true,
+                    source = EvidenceSource.IPTABLES_RULES,
+                    confidence = EvidenceConfidence.MEDIUM,
+                ),
+            )
+            evidence.add(
+                EvidenceItem(
+                    source = EvidenceSource.IPTABLES_RULES,
+                    detected = true,
+                    confidence = EvidenceConfidence.MEDIUM,
+                    description = "iptables NAT rules with REDIRECT/DNAT/TPROXY target",
+                ),
+            )
+            detected = true
+        } else if (iptablesOutput != null) {
+            findings.add(
+                Finding(
+                    description = "iptables accessible: nat table rules present",
+                    isInformational = true,
+                    source = EvidenceSource.IPTABLES_RULES,
+                    confidence = EvidenceConfidence.LOW,
+                ),
+            )
+        } else {
+            findings.add(
+                Finding(
+                    description = "iptables tables found but rules inaccessible (no root)",
+                    isInformational = true,
+                    source = EvidenceSource.IPTABLES_RULES,
+                ),
+            )
+        }
+
+        return IptablesCheckOutcome(findings, evidence, detected, needsReview)
+    }
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    internal fun checkUserInstalledCertificates(): CertCheckOutcome {
+        val findings = mutableListOf<Finding>()
+        val evidence = mutableListOf<EvidenceItem>()
+        var needsReview = false
+
+        var userCaCount = 0
+        val keyStoreResult = runCatching {
+            val ks = java.security.KeyStore.getInstance("AndroidCAStore")
+            ks.load(null, null)
+            userCaCount = ks.aliases().asSequence()
+                .filter { alias -> alias.startsWith("user:") }
+                .count()
+        }
+        if (keyStoreResult.isFailure) {
+            Log.w("IndirectSigns", "AndroidCAStore access failed: ${keyStoreResult.exceptionOrNull()?.message}")
+        }
+
+        if (userCaCount > 0) {
+            findings.add(
+                Finding(
+                    description = "User-installed CA certificates ($userCaCount found in AndroidCAStore) — possible MITM proxy",
+                    needsReview = true,
+                    source = EvidenceSource.MITM_PROXY_CERT,
+                    confidence = EvidenceConfidence.MEDIUM,
+                ),
+            )
+            evidence.add(
+                EvidenceItem(
+                    source = EvidenceSource.MITM_PROXY_CERT,
+                    detected = true,
+                    confidence = EvidenceConfidence.MEDIUM,
+                    description = "$userCaCount user CA certificates installed in AndroidCAStore",
+                ),
+            )
+            needsReview = true
+        }
+
+        if (userCaCount == 0) {
+            val certFiles = runCatching {
+                File("/data/misc/user/0/cacerts-added/").takeIf { it.isDirectory }
+                    ?.listFiles()
+                    ?.filter { it.isFile && it.name.endsWith(".0") }
+                    .orEmpty()
+            }.getOrDefault(emptyList())
+
+            if (certFiles.isNotEmpty()) {
+                findings.add(
+                    Finding(
+                        description = "User CA certificates detected via filesystem (${certFiles.size} files in cacerts-added) — possible MITM proxy",
+                        needsReview = true,
+                        source = EvidenceSource.MITM_PROXY_CERT,
+                        confidence = EvidenceConfidence.MEDIUM,
+                    ),
+                )
+                evidence.add(
+                    EvidenceItem(
+                        source = EvidenceSource.MITM_PROXY_CERT,
+                        detected = true,
+                        confidence = EvidenceConfidence.MEDIUM,
+                        description = "${certFiles.size} user CA certificate files found on filesystem",
+                    ),
+                )
+                needsReview = true
+            }
+        }
+
+        val modifiedDirOk = runCatching {
+            File("/data/misc/user/0/cacerts-modified/").takeIf { it.isDirectory }?.listFiles()?.isNotEmpty()
+        }.getOrDefault(false) == true
+
+        if (modifiedDirOk) {
+            findings.add(
+                Finding(
+                    description = "System CA certificates have been modified (cacerts-modified present)",
+                    needsReview = true,
+                    source = EvidenceSource.MITM_PROXY_CERT,
+                    confidence = EvidenceConfidence.LOW,
+                ),
+            )
+            evidence.add(
+                EvidenceItem(
+                    source = EvidenceSource.MITM_PROXY_CERT,
+                    detected = true,
+                    confidence = EvidenceConfidence.LOW,
+                    description = "System CA trust store was modified",
+                ),
+            )
+            needsReview = true
+        }
+
+        return CertCheckOutcome(findings, evidence, needsReview)
     }
 
     internal fun parseProcNetListeners(lines: List<String>, protocol: String): List<LocalSocketListener> =

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/NativeSignsChecker.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/NativeSignsChecker.kt
@@ -765,19 +765,7 @@ object NativeSignsChecker {
                         EvidenceConfidence.HIGH,
                     )
                 }
-                "selinux" -> {
-                    if (detail == "permissive") {
-                        Pair(
-                            context.getString(R.string.checker_native_root_selinux_permissive),
-                            EvidenceConfidence.HIGH,
-                        )
-                    } else {
-                        Pair(
-                            context.getString(R.string.checker_native_root_selinux_absent),
-                            EvidenceConfidence.LOW,
-                        )
-                    }
-                }
+                "selinux" -> continue
                 "root_uid" -> Pair(
                     context.getString(R.string.checker_native_root_uid, detail),
                     EvidenceConfidence.HIGH,

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/NativeSignsChecker.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/NativeSignsChecker.kt
@@ -24,6 +24,8 @@ import java.net.NetworkInterface
 
 object NativeSignsChecker {
 
+    internal var jvmInterfacesOverride: (() -> List<JvmInterfaceSnapshot>)? = null
+
     private val HIGH_CONFIDENCE_HOOK_MARKERS = setOf(
         "frida-agent",
         "frida-gadget",
@@ -97,7 +99,7 @@ object NativeSignsChecker {
         var needsReview = false
 
         val nativeInterfaces = runCatching { NativeInterfaceProbe.collectInterfaces() }.getOrDefault(emptyList())
-        val jvmInterfaces = runCatching { collectJvmInterfaces() }.getOrDefault(emptyList())
+        val jvmInterfaces = runCatching { jvmInterfacesOverride?.invoke() ?: collectJvmInterfaces() }.getOrDefault(emptyList())
 
         val interfaceOutcome = evaluateInterfaces(context, nativeInterfaces)
         findings += interfaceOutcome.findings

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/VerdictEngine.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/VerdictEngine.kt
@@ -11,8 +11,10 @@ import com.notcvnt.rknhardering.model.Verdict
 import com.notcvnt.rknhardering.model.VerdictDecision
 import com.notcvnt.rknhardering.model.VerdictParticipant
 import com.notcvnt.rknhardering.model.VerdictRuleCode
+import android.util.Log
 
 object VerdictEngine {
+    private const val TAG = "VerdictEngine"
 
     private val HARD_DETECT_BYPASS = setOf(
         EvidenceSource.SPLIT_TUNNEL_BYPASS,
@@ -35,6 +37,8 @@ object VerdictEngine {
         EvidenceSource.ROUTING,
         EvidenceSource.DNS,
         EvidenceSource.PROXY_TECHNICAL_SIGNAL,
+        EvidenceSource.IPTABLES_RULES,
+        EvidenceSource.MITM_PROXY_CERT,
         EvidenceSource.NATIVE_INTERFACE,
         EvidenceSource.NATIVE_ROUTE,
         EvidenceSource.NATIVE_JVM_MISMATCH,
@@ -79,6 +83,32 @@ object VerdictEngine {
         ipConsensus: IpConsensusResult,
         nativeSigns: CategoryResult = CategoryResult(name = "", detected = false, findings = emptyList()),
         icmpSpoofing: CategoryResult = CategoryResult(name = "", detected = false, findings = emptyList()),
+        geoCheckAvailable: Boolean = true,
+    ): VerdictDecision {
+        return try {
+            evaluateDetailedInternal(
+                geoIp, directSigns, indirectSigns, locationSignals,
+                bypassResult, ipConsensus, nativeSigns, icmpSpoofing, geoCheckAvailable,
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "evaluateDetailed failed", e)
+            decision(
+                Verdict.NEEDS_REVIEW,
+                VerdictRuleCode.R5_MATRIX_DEFAULT,
+                participant("evaluate_detailed_error", setOf(EvidenceSource.VERDICT_ENGINE)),
+            )
+        }
+    }
+
+    private fun evaluateDetailedInternal(
+        geoIp: CategoryResult,
+        directSigns: CategoryResult,
+        indirectSigns: CategoryResult,
+        locationSignals: CategoryResult,
+        bypassResult: BypassResult,
+        ipConsensus: IpConsensusResult,
+        nativeSigns: CategoryResult,
+        icmpSpoofing: CategoryResult,
         geoCheckAvailable: Boolean = true,
     ): VerdictDecision {
         // R1
@@ -150,7 +180,7 @@ object VerdictEngine {
         }
         if (locationConfirmsRussia &&
             (geo?.hosting == true || geo?.proxyDb == true) &&
-            geo.outsideRu != true &&
+            geo?.outsideRu != true &&
             !anyOtherSignal
         ) {
             return decision(
@@ -161,8 +191,11 @@ object VerdictEngine {
             )
         }
 
+        val whitelistEntry = geo?.let(CorporateVpnWhitelist::match)
+        val whitelisted = whitelistEntry != null
+
         // R5 — 3-bit matrix (geo x direct x indirect)
-        val geoHit = geo?.outsideRu == true && !expectedRoamingExit
+        val geoHit = geo?.outsideRu == true && !expectedRoamingExit && !whitelisted
         val directHit = directSigns.evidence.any { it.detected && it.source in MATRIX_DIRECT_SOURCES }
         val indirectHit = indirectSigns.evidence.any { it.detected && it.source in MATRIX_INDIRECT_SOURCES } ||
             nativeSigns.evidence.any {
@@ -176,8 +209,7 @@ object VerdictEngine {
             !geoHit && directHit && !indirectHit -> Verdict.NOT_DETECTED
             !geoHit && !directHit && indirectHit -> Verdict.NOT_DETECTED
             geoHit && !directHit && !indirectHit -> Verdict.NEEDS_REVIEW
-            !geoHit && directHit && indirectHit ->
-                if (geoAxisAvailable) Verdict.NEEDS_REVIEW else Verdict.DETECTED
+            !geoHit && directHit && indirectHit -> Verdict.NEEDS_REVIEW
             geoHit && directHit && !indirectHit -> Verdict.DETECTED
             geoHit && !directHit && indirectHit -> Verdict.DETECTED
             geoHit && directHit && indirectHit -> Verdict.DETECTED
@@ -237,15 +269,19 @@ object VerdictEngine {
             }
             if (geoHit) add(EvidenceSource.GEO_IP)
         }
-        return decision(
-            matrix,
-            VerdictRuleCode.R5_MATRIX,
+        val r5Participants = mutableListOf(
             participant("geo=$geoHit"),
             participant("direct=$directHit"),
             participant("indirect=$indirectHit", matrixSources),
             participant("geo_available=$geoAxisAvailable"),
             participant("expected_roaming_exit=$expectedRoamingExit"),
         )
+        if (whitelisted) {
+            r5Participants.add(
+                participant("corporate_vpn_whitelisted=${whitelistEntry?.name}", setOf(EvidenceSource.CORPORATE_VPN_WHITELIST)),
+            )
+        }
+        return decision(matrix, VerdictRuleCode.R5_MATRIX, *r5Participants.toTypedArray())
     }
 
     private fun participant(

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/VerdictEngine.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/VerdictEngine.kt
@@ -192,10 +192,9 @@ object VerdictEngine {
         }
 
         val whitelistEntry = geo?.let(CorporateVpnWhitelist::match)
-        val whitelisted = whitelistEntry != null
 
         // R5 — 3-bit matrix (geo x direct x indirect)
-        val geoHit = geo?.outsideRu == true && !expectedRoamingExit && !whitelisted
+        val geoHit = geo?.outsideRu == true && !expectedRoamingExit
         val directHit = directSigns.evidence.any { it.detected && it.source in MATRIX_DIRECT_SOURCES }
         val indirectHit = indirectSigns.evidence.any { it.detected && it.source in MATRIX_INDIRECT_SOURCES } ||
             nativeSigns.evidence.any {
@@ -209,7 +208,8 @@ object VerdictEngine {
             !geoHit && directHit && !indirectHit -> Verdict.NOT_DETECTED
             !geoHit && !directHit && indirectHit -> Verdict.NOT_DETECTED
             geoHit && !directHit && !indirectHit -> Verdict.NEEDS_REVIEW
-            !geoHit && directHit && indirectHit -> Verdict.NEEDS_REVIEW
+            !geoHit && directHit && indirectHit ->
+                if (geoAxisAvailable) Verdict.NEEDS_REVIEW else Verdict.DETECTED
             geoHit && directHit && !indirectHit -> Verdict.DETECTED
             geoHit && !directHit && indirectHit -> Verdict.DETECTED
             geoHit && directHit && indirectHit -> Verdict.DETECTED
@@ -276,9 +276,9 @@ object VerdictEngine {
             participant("geo_available=$geoAxisAvailable"),
             participant("expected_roaming_exit=$expectedRoamingExit"),
         )
-        if (whitelisted) {
+        if (whitelistEntry != null) {
             r5Participants.add(
-                participant("corporate_vpn_whitelisted=${whitelistEntry?.name}", setOf(EvidenceSource.CORPORATE_VPN_WHITELIST)),
+                participant("corporate_vpn_whitelisted=${whitelistEntry.name}", setOf(EvidenceSource.CORPORATE_VPN_WHITELIST)),
             )
         }
         return decision(matrix, VerdictRuleCode.R5_MATRIX, *r5Participants.toTypedArray())

--- a/app/src/main/java/com/notcvnt/rknhardering/checker/VpnNativeDetectorChecker.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/checker/VpnNativeDetectorChecker.kt
@@ -19,8 +19,10 @@ import kotlinx.coroutines.withContext
  */
 object VpnNativeDetectorChecker {
 
+    // fib_trie_denied and inet_diag_denied are excluded:
+    // SELinux blocks these on any stock Android — they are not VPN indicators.
     private val NETWORK_KINDS = setOf(
-        "fib_trie_denied", "inet_diag_denied", "bindtodevice_leak",
+        "bindtodevice_leak",
         "getsockname_leak", "udp_port_conflict_physical", "vpn_qdisc",
         "bpf_map_accessible", "route_count", "trim_oracle",
     )
@@ -36,6 +38,11 @@ object VpnNativeDetectorChecker {
         "proc_if_inet6_vpn", "proc_ipv6_route_vpn", "proc_net_dev_vpn",
         "ifindexname_vpn", "vpn_policy_rules_netlink",
         "bindtodevice_leak", "getsockname_leak", "udp_port_conflict_physical",
+    )
+
+    // Skipped entirely: SELinux blocks these on stock Android, not VPN indicators.
+    private val SKIPPED_KINDS = setOf(
+        "fib_trie_denied", "inet_diag_denied",
     )
 
     private val INFORMATIONAL_KINDS = setOf(
@@ -117,6 +124,7 @@ object VpnNativeDetectorChecker {
         val evidence = mutableListOf<EvidenceItem>()
 
         for (item in parsed) {
+            if (item.kind in SKIPPED_KINDS) continue
             evaluateItem(context, item, findings, evidence)
         }
 
@@ -159,8 +167,6 @@ object VpnNativeDetectorChecker {
             "proc_net_dev_vpn" -> R.string.vpn_desc_proc_net_dev
             "ifindexname_vpn" -> R.string.vpn_desc_ifindexname
             "vpn_policy_rules_netlink" -> R.string.vpn_desc_policy_rules_netlink
-            "fib_trie_denied" -> R.string.vpn_desc_fib_trie
-            "inet_diag_denied" -> R.string.vpn_desc_inet_diag
             "bindtodevice_leak" -> R.string.vpn_desc_bindtodevice_leak
             "getsockname_leak" -> R.string.vpn_desc_getsockname
             "udp_port_conflict_physical" -> R.string.vpn_desc_udp_port_physical

--- a/app/src/main/java/com/notcvnt/rknhardering/customcheck/CustomCheckProfile.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/customcheck/CustomCheckProfile.kt
@@ -131,6 +131,8 @@ data class IndirectSignsConfig(
     val checkProxyTools: Boolean = true,
     val checkLocalListeners: Boolean = true,
     val checkDumpsys: Boolean = true,
+    val checkIptables: Boolean = true,
+    val checkUserCerts: Boolean = true,
     val listenerPortThreshold: Int = 5,
 )
 

--- a/app/src/main/java/com/notcvnt/rknhardering/customcheck/CustomCheckSerializer.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/customcheck/CustomCheckSerializer.kt
@@ -165,6 +165,8 @@ object CustomCheckSerializer {
         obj.put("check_proxy_tools", i.checkProxyTools)
         obj.put("check_local_listeners", i.checkLocalListeners)
         obj.put("check_dumpsys", i.checkDumpsys)
+        obj.put("check_iptables", i.checkIptables)
+        obj.put("check_user_certs", i.checkUserCerts)
         obj.put("listener_port_threshold", i.listenerPortThreshold)
         return obj
     }
@@ -493,6 +495,8 @@ object CustomCheckSerializer {
         checkProxyTools = obj.optBoolean("check_proxy_tools", true),
         checkLocalListeners = obj.optBoolean("check_local_listeners", true),
         checkDumpsys = obj.optBoolean("check_dumpsys", true),
+        checkIptables = obj.optBoolean("check_iptables", true),
+        checkUserCerts = obj.optBoolean("check_user_certs", true),
         listenerPortThreshold = obj.optInt("listener_port_threshold", 5),
     )
 

--- a/app/src/main/java/com/notcvnt/rknhardering/model/CheckResult.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/model/CheckResult.kt
@@ -86,6 +86,12 @@ enum class EvidenceSource {
     NATIVE_ROOT_DETECTION,
     NATIVE_EMULATOR,
     SANDBOX_ISOLATION,
+    VERDICT_ENGINE,
+
+    CORPORATE_VPN_WHITELIST,
+    HTTP_PROXY_HEADER,
+    IPTABLES_RULES,
+    MITM_PROXY_CERT,
 }
 
 enum class StunScope {
@@ -296,6 +302,7 @@ enum class VerdictRuleCode(val code: String) {
     R4_LOCATION_GEO_CONFLICT("R4"),
     R4_HOSTING_REVIEW("R4"),
     R5_MATRIX("R5"),
+    R5_MATRIX_DEFAULT("R5"),
     R6_FALLBACK("R6"),
     UNSPECIFIED("unknown"),
 }

--- a/app/src/main/java/com/notcvnt/rknhardering/network/ResolverBinding.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/network/ResolverBinding.kt
@@ -67,14 +67,18 @@ internal object ResolverSocketBinder {
     }
 
     private fun bindSocketToDevice(socket: Socket, interfaceName: String) {
-        bindSocketToDeviceOverride?.invoke(socket, interfaceName) ?: ParcelFileDescriptor.fromSocket(socket).use { pfd ->
-            bindFileDescriptorToDevice(pfd.fileDescriptor, interfaceName)
+        bindSocketToDeviceOverride?.invoke(socket, interfaceName) ?: runCatching {
+            ParcelFileDescriptor.fromSocket(socket).use { pfd ->
+                bindFileDescriptorToDevice(pfd.fileDescriptor, interfaceName)
+            }
         }
     }
 
     private fun bindDatagramToDevice(socket: DatagramSocket, interfaceName: String) {
-        bindDatagramToDeviceOverride?.invoke(socket, interfaceName) ?: ParcelFileDescriptor.fromDatagramSocket(socket).use { pfd ->
-            bindFileDescriptorToDevice(pfd.fileDescriptor, interfaceName)
+        bindDatagramToDeviceOverride?.invoke(socket, interfaceName) ?: runCatching {
+            ParcelFileDescriptor.fromDatagramSocket(socket).use { pfd ->
+                bindFileDescriptorToDevice(pfd.fileDescriptor, interfaceName)
+            }
         }
     }
 

--- a/app/src/main/java/com/notcvnt/rknhardering/network/ResolverBinding.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/network/ResolverBinding.kt
@@ -67,18 +67,24 @@ internal object ResolverSocketBinder {
     }
 
     private fun bindSocketToDevice(socket: Socket, interfaceName: String) {
-        bindSocketToDeviceOverride?.invoke(socket, interfaceName) ?: runCatching {
+        bindSocketToDeviceOverride?.invoke(socket, interfaceName) ?: try {
             ParcelFileDescriptor.fromSocket(socket).use { pfd ->
                 bindFileDescriptorToDevice(pfd.fileDescriptor, interfaceName)
             }
+        } catch (e: RuntimeException) {
+            if (e.message?.contains("EBADF") == true) return
+            throw e
         }
     }
 
     private fun bindDatagramToDevice(socket: DatagramSocket, interfaceName: String) {
-        bindDatagramToDeviceOverride?.invoke(socket, interfaceName) ?: runCatching {
+        bindDatagramToDeviceOverride?.invoke(socket, interfaceName) ?: try {
             ParcelFileDescriptor.fromDatagramSocket(socket).use { pfd ->
                 bindFileDescriptorToDevice(pfd.fileDescriptor, interfaceName)
             }
+        } catch (e: RuntimeException) {
+            if (e.message?.contains("EBADF") == true) return
+            throw e
         }
     }
 

--- a/app/src/main/java/com/notcvnt/rknhardering/ui/main/SimpleResultModels.kt
+++ b/app/src/main/java/com/notcvnt/rknhardering/ui/main/SimpleResultModels.kt
@@ -261,7 +261,9 @@ internal object SimpleResultModels {
     private fun signalArea(sources: Set<EvidenceSource>): SimpleSignalArea {
         val areas = sources.mapTo(linkedSetOf()) { source ->
             when (source) {
-                EvidenceSource.GEO_IP -> SimpleSignalArea.PUBLIC_ADDRESS
+                EvidenceSource.GEO_IP,
+                EvidenceSource.CORPORATE_VPN_WHITELIST,
+                -> SimpleSignalArea.PUBLIC_ADDRESS
                 EvidenceSource.INSTALLED_APP,
                 EvidenceSource.VPN_SERVICE_DECLARATION,
                 EvidenceSource.ACTIVE_VPN,
@@ -271,6 +273,9 @@ internal object SimpleResultModels {
                 EvidenceSource.CLASH_API,
                 EvidenceSource.PROXY_AUTH_BYPASS,
                 EvidenceSource.PROXY_TECHNICAL_SIGNAL,
+                EvidenceSource.HTTP_PROXY_HEADER,
+                EvidenceSource.IPTABLES_RULES,
+                EvidenceSource.MITM_PROXY_CERT,
                 -> SimpleSignalArea.LOCAL_PROXY
                 EvidenceSource.ROUTING,
                 EvidenceSource.DNS,
@@ -300,6 +305,7 @@ internal object SimpleResultModels {
                 EvidenceSource.NATIVE_ROOT_DETECTION,
                 EvidenceSource.NATIVE_EMULATOR,
                 EvidenceSource.SANDBOX_ISOLATION,
+                EvidenceSource.VERDICT_ENGINE,
                 EvidenceSource.DUMPSYS,
                 -> SimpleSignalArea.DEVICE_ENVIRONMENT
                 EvidenceSource.ICMP_SPOOFING,
@@ -315,7 +321,9 @@ internal object SimpleResultModels {
     }
 
     private fun signalCause(source: EvidenceSource): SimpleResultCause? = when (source) {
-        EvidenceSource.GEO_IP -> SimpleResultCause.PUBLIC_IP_LOCATION
+        EvidenceSource.GEO_IP,
+        EvidenceSource.CORPORATE_VPN_WHITELIST,
+        -> SimpleResultCause.PUBLIC_IP_LOCATION
         EvidenceSource.DIRECT_NETWORK_CAPABILITIES,
         EvidenceSource.INDIRECT_NETWORK_CAPABILITIES,
         EvidenceSource.DUMPSYS,
@@ -326,6 +334,9 @@ internal object SimpleResultModels {
         EvidenceSource.XRAY_API,
         EvidenceSource.CLASH_API,
         EvidenceSource.PROXY_TECHNICAL_SIGNAL,
+        EvidenceSource.HTTP_PROXY_HEADER,
+        EvidenceSource.IPTABLES_RULES,
+        EvidenceSource.MITM_PROXY_CERT,
         -> SimpleResultCause.LOCAL_PROXY
         EvidenceSource.PROXY_AUTH_BYPASS -> SimpleResultCause.PROXY_AUTH_REQUIRED
         EvidenceSource.NETWORK_INTERFACE,
@@ -356,6 +367,7 @@ internal object SimpleResultModels {
         EvidenceSource.NATIVE_ROOT_DETECTION,
         EvidenceSource.NATIVE_EMULATOR,
         EvidenceSource.SANDBOX_ISOLATION,
+        EvidenceSource.VERDICT_ENGINE,
         -> SimpleResultCause.DEVICE_ENVIRONMENT
         EvidenceSource.INSTALLED_APP,
         EvidenceSource.VPN_SERVICE_DECLARATION,

--- a/app/src/test/java/com/notcvnt/rknhardering/checker/CallTransportCheckerTest.kt
+++ b/app/src/test/java/com/notcvnt/rknhardering/checker/CallTransportCheckerTest.kt
@@ -172,7 +172,10 @@ class CallTransportCheckerTest {
             publicIpFetcher = { _, _, _ -> Result.success("203.0.113.10") },
             proxyProbe = {
                 delay(500)
-                CallTransportChecker.ProxyProbeOutcome(reachable = false)
+                CallTransportChecker.ProxyProbeOutcome(
+                    reachable = false,
+                    observedPublicIp = "203.0.113.10",
+                )
             },
             proxyUdpStunProbe = { _, _, _, _ ->
                 delay(500)

--- a/app/src/test/java/com/notcvnt/rknhardering/checker/IndirectSignsCheckerTest.kt
+++ b/app/src/test/java/com/notcvnt/rknhardering/checker/IndirectSignsCheckerTest.kt
@@ -597,13 +597,15 @@ class IndirectSignsCheckerTest {
 
     @Test
     fun `when checkVpnInterfaces=false the vpn-interfaces finding is skipped`() = runBlocking {
-        // With the toggle disabled the checkNetworkInterfaces path is entirely bypassed.
-        // In Robolectric there are no real VPN interfaces, so evidence from NETWORK_INTERFACE
-        // should be absent in both cases. The assertion confirms no exception is thrown and
-        // no detected NETWORK_INTERFACE evidence appears when the toggle is off.
+        // With the toggle disabled the checkNetworkInterfaces and checkMtu paths are entirely
+        // bypassed. The assertion confirms no exception is thrown and no detected
+        // NETWORK_INTERFACE evidence appears when the toggle is off.
         val result = IndirectSignsChecker.check(
             context = context,
-            config = IndirectSignsConfig(checkVpnInterfaces = false),
+            config = IndirectSignsConfig(
+                checkVpnInterfaces = false,
+                checkMtuAnomaly = false,
+            ),
         )
 
         assertFalse(

--- a/app/src/test/java/com/notcvnt/rknhardering/checker/NativeSignsCheckerTest.kt
+++ b/app/src/test/java/com/notcvnt/rknhardering/checker/NativeSignsCheckerTest.kt
@@ -25,6 +25,7 @@ class NativeSignsCheckerTest {
     @Before
     fun setUp() {
         NativeSignsBridge.resetForTests()
+        NativeSignsChecker.jvmInterfacesOverride = null
         NativeSignsBridge.isLibraryLoadedOverride = { true }
         NativeSignsBridge.getIfAddrsOverride = { emptyArray() }
         NativeSignsBridge.ifNameToIndexOverride = { 0 }
@@ -38,6 +39,7 @@ class NativeSignsCheckerTest {
     @After
     fun tearDown() {
         NativeSignsBridge.resetForTests()
+        NativeSignsChecker.jvmInterfacesOverride = null
     }
 
     @Test
@@ -104,6 +106,18 @@ class NativeSignsCheckerTest {
     fun `clean native state produces ok result`() {
         NativeSignsBridge.getIfAddrsOverride = {
             arrayOf("wlan0|3|65|AF_INET|192.168.1.10|255.255.255.0|1500")
+        }
+        NativeSignsChecker.jvmInterfacesOverride = {
+            listOf(
+                NativeSignsChecker.JvmInterfaceSnapshot(
+                    name = "wlan0",
+                    canonicalName = "wlan0",
+                    index = 3,
+                    addresses = setOf("192.168.1.10"),
+                    mtu = 1500,
+                    isUp = true,
+                ),
+            )
         }
         NativeSignsBridge.libraryIntegrityOverride = {
             arrayOf(


### PR DESCRIPTION
## Итак , я тут с методичкой МинЦифры поигрался

 - Убрал fib_trie_denied и inet_diag_denied — SELinux их всё равно блокирует, толку ноль
- Убрал статус SELinux из нативных признаков (не показатель VPN)
- Попытался добавить детект прокси-хедеров через CDN Pulling (WARP, X-Forwarded-*)
- Попытался нахуярить whitelist корпоративных VPN (реальные ASN: Сбер, ВТБ, Газпром, Яндекс, VK и т.д.)
- Переписал проверку сертификатов на AndroidCAStore KeyStore API (работает без root)
- Пофиксил iptables проверку — теперь молча пропускается если SELinux не даёт
- Обернул краш ResolverBinding (EBADF при fromSocket) в runCatching
- Пофиксил VerdictEngine — try-catch чтоб не валил весь скан
- Добавил недостающие ветки в SimpleResultModels (чтоб не падало на новых EvidenceSource)